### PR TITLE
Works with Scala 2.12 and Spark 3.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@ limitations under the License.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!--Maven-->
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.deploy.plugin.version>2.8.1</maven.deploy.plugin.version>
         <maven.sources.version>3.0.1</maven.sources.version>
         <gpg.plugin.version>1.6</gpg.plugin.version>
@@ -58,15 +58,17 @@ limitations under the License.
         <h2.version>2.0.206</h2.version>
 
         <!--Scala-->
-        <scala.version>2.11.12</scala.version>
-        <scala.compat.version>2.11</scala.compat.version>
+        <scala.version>2.12.18</scala.version>
+        <scala.compat.version>2.12</scala.compat.version>
         <specs.version>4.7.1</specs.version>
 
         <!--Spark-->
-        <spark.version>2.4.4</spark.version>
+        <spark.version>3.2.4</spark.version>
 
         <!--Play-->
         <play.json.version>2.7.4</play.json.version>
+
+        <jackson.version>2.12.0</jackson.version>
     </properties>
 
     <scm>
@@ -118,6 +120,24 @@ limitations under the License.
             <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
+
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
 
         <!--Play/JSON-->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@ limitations under the License.
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>za.co.absa</groupId>
-    <artifactId>jdbc2s_2.11</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <artifactId>jdbc2s_2.12</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
     <name>jdbc2s</name>
     <description>JDBC streaming source for Spark</description>
     <url>https://github.com/AbsaOSS/Jdbc2S</url>

--- a/src/main/scala/org/apache/spark/sql/execution/streaming/sources/JDBCStreamingSourceV1.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/streaming/sources/JDBCStreamingSourceV1.scala
@@ -477,6 +477,7 @@ class JDBCStreamingSourceV1(sqlContext: SQLContext,
       .options(parameters)
       .option(JDBCOptions.JDBC_TABLE_NAME, s"($query)")
       .load()
+      .alias(JDBCOptions.JDBC_TABLE_NAME.take(2))
   }
 
   /**

--- a/src/main/scala/org/apache/spark/sql/execution/streaming/sources/JDBCStreamingSourceV1.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/streaming/sources/JDBCStreamingSourceV1.scala
@@ -260,6 +260,8 @@ class JDBCStreamingSourceV1(sqlContext: SQLContext,
   private def findOffset(offsetType: OffsetType, filter: Option[String]): Option[String] = {
     val offsetRetrievalQuery = offsetQueryMaker.make(offsetType, filter)
 
+    logDebug(s"offsetRetrievalQuery: $offsetRetrievalQuery")
+
     val offsetValue = getFirstColValAsString(offsetRetrievalQuery)
     logInfo(msg = s"Inferred from data as '$offsetType': $offsetValue")
     offsetValue
@@ -275,7 +277,7 @@ class JDBCStreamingSourceV1(sqlContext: SQLContext,
         .read
         .format(source = "jdbc")
         .options(parameters)
-        .option(JDBCOptions.JDBC_TABLE_NAME, s"($query)")
+        .option(JDBCOptions.JDBC_TABLE_NAME, s"($query) AS O1")
         .load()
         .first()
 
@@ -475,7 +477,7 @@ class JDBCStreamingSourceV1(sqlContext: SQLContext,
       .read
       .format(source = "jdbc")
       .options(parameters)
-      .option(JDBCOptions.JDBC_TABLE_NAME, s"($query)")
+      .option(JDBCOptions.JDBC_TABLE_NAME, s"($query) AS B1")
       .load()
       .alias(JDBCOptions.JDBC_TABLE_NAME.take(2))
   }

--- a/src/main/scala/org/apache/spark/sql/execution/streaming/sources/query/BatchQueryMaker.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/streaming/sources/query/BatchQueryMaker.scala
@@ -51,7 +51,7 @@ private[sources] class BatchQueryMaker(tableName: String, offsetField: String, o
     val operator = getOperator(offsetType, offsetOperationType)
 
     offsetFieldType match {
-      case DATE => s"$offsetField $operator to_date('$filterValue','${offsetFieldDateFormat.get}')"
+      case DATE => s"$offsetField $operator CAST('$filterValue' AS DATE)"
       case STRING => s"$offsetField $operator '$filterValue'"
       case NUMBER => s"$offsetField $operator $filterValue"
     }

--- a/src/main/scala/org/apache/spark/sql/execution/streaming/sources/query/OffsetQueryMaker.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/streaming/sources/query/OffsetQueryMaker.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.execution.streaming.sources.types.OffsetSupportedTyp
   *
   * This class was created because the query will be different depending on the data type.
   *
-  * For instance, dates should be converted by invoking 'to_date' from Spark SQL functions where numbers don't need
+  * For instance, dates should be converted by invoking 'CAST(${my_date} AS DATE)' from Spark SQL functions where numbers don't need
   * any special treatment.
   *
   * @param table     String containing the name of the table to be queried.
@@ -59,7 +59,7 @@ private[sources] class OffsetQueryMaker(table: String, fieldName: String, dataTy
     }
 
     dataType match {
-      case DATE => s"$fieldName $operation to_date('$filterValue', '${format.get}')"
+      case DATE => s"$fieldName $operation CAST('$filterValue' AS DATE)"
       case STRING => s"$fieldName $operation '$filterValue'"
       case NUMBER => s"$fieldName $operation $filterValue"
     }

--- a/src/main/scala/org/apache/spark/sql/execution/streaming/sources/types/OffsetSupportedTypes.scala
+++ b/src/main/scala/org/apache/spark/sql/execution/streaming/sources/types/OffsetSupportedTypes.scala
@@ -15,12 +15,13 @@
 
 package org.apache.spark.sql.execution.streaming.sources.types
 
-import org.apache.spark.sql.types.{DataType, DateType, StructField, StructType}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.types.{DataType, DateType, StructField, StructType, TimestampType}
 
 /**
   * Currently data types can only be dates, strings and numbers
   */
-object OffsetSupportedTypes extends Enumeration {
+object OffsetSupportedTypes extends Enumeration with Logging {
   type OffsetDataType = Value
   val DATE, STRING, NUMBER = Value
 
@@ -49,8 +50,9 @@ object OffsetSupportedTypes extends Enumeration {
     * This piggies-back on the inference available at [[org.apache.spark.sql.execution.datasources.jdbc.JdbcRelationProvider.createRelation()]]
     */
   private def getSupportedType(field: StructField): OffsetDataType = {
+    logDebug(s"Data type: $field")
     field.dataType match {
-      case _: DateType => DATE
+      case _: DateType | TimestampType => DATE
       case t: DataType if t.typeName.toLowerCase.contains("string") => STRING
       case _ => NUMBER
     }

--- a/src/main/scala/za/co/absa/spark/jdbc/streaming/source/offsets/JDBCSingleFieldOffset.scala
+++ b/src/main/scala/za/co/absa/spark/jdbc/streaming/source/offsets/JDBCSingleFieldOffset.scala
@@ -15,7 +15,7 @@
 
 package za.co.absa.spark.jdbc.streaming.source.offsets
 
-import org.apache.spark.sql.sources.v2.reader.streaming.Offset
+import org.apache.spark.sql.execution.streaming.Offset
 
 case class OffsetRange(start: Option[String], end: Option[String]) {
 

--- a/src/main/scala/za/co/absa/spark/jdbc/streaming/source/providers/JDBCStreamingSourceProviderV1.scala
+++ b/src/main/scala/za/co/absa/spark/jdbc/streaming/source/providers/JDBCStreamingSourceProviderV1.scala
@@ -20,7 +20,6 @@ import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.execution.streaming.Source
 import org.apache.spark.sql.execution.streaming.sources.JDBCStreamingSourceV1
-import org.apache.spark.sql.sources.v2.DataSourceV2
 import org.apache.spark.sql.sources.{DataSourceRegister, StreamSourceProvider}
 import org.apache.spark.sql.types.StructType
 
@@ -30,7 +29,7 @@ import org.apache.spark.sql.types.StructType
   * Although [[JDBCStreamingSourceV1]] implements Spark DataSourceV1, this provider is marked as DataSourceV2 for
   * forward compatibility.
   */
-class JDBCStreamingSourceProviderV1 extends StreamSourceProvider with DataSourceV2 with DataSourceRegister {
+class JDBCStreamingSourceProviderV1 extends StreamSourceProvider with DataSourceRegister {
 
   private lazy val batchJDBCDataFrame = (sqlContext: SQLContext, parameters: Map[String, String]) => {
     sqlContext

--- a/src/test/scala/org/apache/spark/sql/execution/streaming/sources/TestIntegrationJDBCStreamingSourceV1.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/streaming/sources/TestIntegrationJDBCStreamingSourceV1.scala
@@ -69,7 +69,7 @@ class TestIntegrationJDBCStreamingSourceV1 extends FunSuite with SparkTestBase {
     val tableName = randomTableName
     val offsetField = "d"
     val params = Map(CONFIG_OFFSET_FIELD -> offsetField,
-      CONFIG_OFFSET_FIELD_DATE_FORMAT -> "YYYY-MM-DD") ++ jdbcDefaultConnectionParams(tableName)
+      CONFIG_OFFSET_FIELD_DATE_FORMAT -> "yyyy-MM-dd") ++ jdbcDefaultConnectionParams(tableName)
 
     val expected = randomTestData(startDate = "2020-01-01", endDate = "2020-01-05")
     writeToJDBC[TestClass](spark, params, expected)

--- a/src/test/scala/org/apache/spark/sql/execution/streaming/sources/query/TestBatchQueryMaker.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/streaming/sources/query/TestBatchQueryMaker.scala
@@ -41,8 +41,8 @@ class TestBatchQueryMaker extends FunSuite {
     val condition = dataType match {
       case NUMBER => s"$offsetField $operation $start AND $offsetField <= $end"
       case STRING => s"$offsetField $operation '$start' AND $offsetField <= '$end'"
-      case DATE => s"$offsetField $operation to_date('$start','${format.get}') AND " +
-        s"$offsetField <= to_date('$end','${format.get}')"
+      case DATE => s"$offsetField $operation CAST('$start' AS DATE) AND " +
+        s"$offsetField <= CAST('$end' AS DATE)"
     }
 
     baseQuery + condition

--- a/src/test/scala/org/apache/spark/sql/execution/streaming/sources/query/TestOffsetQueryMaker.scala
+++ b/src/test/scala/org/apache/spark/sql/execution/streaming/sources/query/TestOffsetQueryMaker.scala
@@ -60,7 +60,7 @@ class TestOffsetQueryMaker extends FunSpec {
       val format = "YYYY-MM-DD"
       val from = "2020-01-01"
 
-      val expected = s"SELECT MAX($fieldName) AS END_OFFSET FROM $tableName WHERE $fieldName >= to_date('$from', '$format')"
+      val expected = s"SELECT MAX($fieldName) AS END_OFFSET FROM $tableName WHERE $fieldName >= CAST('$from' AS DATE)"
 
       val actual = new OffsetQueryMaker(tableName, fieldName, DATE, Some(format)).make(END_OFFSET, Some(from))
 
@@ -127,11 +127,11 @@ class TestOffsetQueryMaker extends FunSpec {
       val format = "YYYY-MM-DD"
       val from = "2020-01-01"
 
-      val expected = s"SELECT MIN($fieldName) AS START_OFFSET FROM $tableName WHERE $fieldName <= to_date('$from', '$format')"
+      val expected = s"SELECT MIN($fieldName) AS START_OFFSET FROM $tableName WHERE $fieldName <= CAST('$from' AS DATE)"
 
       val actual = new OffsetQueryMaker(tableName, fieldName, DATE, Some(format)).make(START_OFFSET, Some(from))
 
-      assert(expected == actual)
+      assert(actual == expected)
     }
 
     it("should just query max STRING field if no 'from' is specified") {


### PR DESCRIPTION
- Remove some deprecated imports
- Change the `to_date` function with a `CAST`
- Add `TimestampType` to be casted as a SQL `Date`